### PR TITLE
feat: Add return request handling and UI updates for order details

### DIFF
--- a/actions/payment-management/add-management.ts
+++ b/actions/payment-management/add-management.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import prismadb from "@/lib/prismadb";
-import { PaymentManagement } from "@prisma/client";
 
 interface ManagementProps {
   shipping: string;

--- a/app/(landing)/orders/[orderId]/_components/order-details.tsx
+++ b/app/(landing)/orders/[orderId]/_components/order-details.tsx
@@ -22,6 +22,7 @@ import { PiContactlessPaymentBold } from "react-icons/pi";
 import { toast } from "sonner";
 import { getUrl } from "@/actions/get-url";
 
+
 interface OrderDetailsPageProps {
   order: Orders;
 }
@@ -126,9 +127,10 @@ const OrderDetails = ({ order }: OrderDetailsPageProps) => {
               Order Summary
             </h1>
             {order.refundableamount === order.amount ||
-            priceAfterDiscount === 0 ? (
+              priceAfterDiscount === 0 ? (
               ""
             ) : (
+
               <>
                 <Separator className="h-[1px] w-full bg-separator" />
                 <div className="w-full flex flex-col gap-4">
@@ -155,6 +157,7 @@ const OrderDetails = ({ order }: OrderDetailsPageProps) => {
                   </div>
                 </div>
               </>
+
             )}
             <Separator className="h-[1px] w-full bg-separator" />
             <div className="w-full flex items-center justify-between">
@@ -208,20 +211,22 @@ const OrderDetails = ({ order }: OrderDetailsPageProps) => {
               className={cn(
                 "flex items-center gap-2 mt-2 md:mt-3 cursor-default pointer-events-none select-none",
                 order?.order_status === "Payment Processing" &&
-                  "pointer-events-auto select-all cursor-pointer",
+                "pointer-events-auto select-all cursor-pointer",
                 order?.order_status === "Payment Failed" ||
                   order?.order_status === "Order Cancelled"
                   ? "bg-red-600"
                   : "bg-emerald-600",
                 order?.order_status === "Payment Processing" &&
-                  "bg-yellow-600 hover:bg-yellow-700"
+                "bg-yellow-600 hover:bg-yellow-700",
+                order?.order_status === "Return Requested" &&
+                "bg-yellow-600 hover:bg-yellow-700"
               )}
             >
               {order?.order_status === "Payment Processing"
                 ? "Continue Payment"
                 : order?.order_status}
               {order?.order_status === "Payment Failed" ||
-              order?.order_status === "Order Cancelled" ? (
+                order?.order_status === "Order Cancelled" ? (
                 <>
                   <XCircle className="size-4 md:size-5 shrink-0 text-white" />
                 </>
@@ -261,9 +266,8 @@ const OrderDetails = ({ order }: OrderDetailsPageProps) => {
         </>
       )}
       {order.order_status == "Payment Failed" ||
-      order.order_status === "Payment Processing" ||
-      order?.order_status === "Order Cancelled" ||
-      order?.order_status === "Return Requested" ? (
+        order.order_status === "Payment Processing" ||
+        order?.order_status === "Order Cancelled" ? (
         ""
       ) : (
         <>
@@ -276,8 +280,7 @@ const OrderDetails = ({ order }: OrderDetailsPageProps) => {
             <OrderStatusProgressBar order_status={order.order_status} />
 
             {order.order_status !== "Order Shipped" &&
-              order.order_status !== "Order Delivered" &&
-              order.order_status !== "Return Requested" && (
+              order.order_status !== "Order Delivered" && (
                 <div className="w-full flex items-center justify-end md:mt-4">
                   <Link href={`/orders/${order?.id}/cancel`}>
                     <Button className="w-[160px] md:w-[200px] bg-green hover:bg-green/90 text-medium text-white h-8 md:h-12">
@@ -288,7 +291,7 @@ const OrderDetails = ({ order }: OrderDetailsPageProps) => {
               )}
             {order.order_status === "Order Delivered" && (
               <div className="w-full flex items-center justify-end md:mt-4">
-                <Link href={`/orders/${order?.id}/return`}>
+                <Link href="/">
                   <Button className="w-[160px] md:w-[200px] bg-green hover:bg-green/90 text-medium text-white h-8 md:h-12">
                     Return Order
                   </Button>

--- a/app/(landing)/orders/[orderId]/return/_components/return-order-page.tsx
+++ b/app/(landing)/orders/[orderId]/return/_components/return-order-page.tsx
@@ -131,13 +131,20 @@ const ReturnOrderPage = ({ order, categories }: OrderReturnPageProps) => {
         (item) => item.name === values.itemName
       );
 
-      const data = {
-        return_reason: values.reason,
-        return_or_refund: values.return_or_refund,
-        returnImages: values.images,
-        returned_items: returned_items,
-        returnWholeOrder: true,
-      };
+      const data =
+        values.itemName.length === order.orderItems.map((item) => item.name).length
+          ? {
+            return_reason: values.reason,
+            return_or_refund: values.return_or_refund,
+            returnImages: values.images,
+            returned_items: returned_items,
+            returnWholeOrder: true,
+          } : {
+            return_reason: values.reason,
+            return_or_refund: values.return_or_refund,
+            returnImages: values.images,
+            returned_items: returned_items,
+          };
 
       const response = await axios.post(
         `${URL}/orders/${order.id}/return`,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,6 +50,7 @@ export default async function RootLayout({
     <SessionProvider session={session}>
       <html lang="en" suppressHydrationWarning>
         <head>
+
           <style>{`
           #content { display: none; }
           #loader { display: flex; }
@@ -70,7 +71,7 @@ export default async function RootLayout({
             <ConfettiProvider />
             <NextTopLoader color="#0D2A25" />
             <ThemeProvider
-              defaultTheme="system"
+              defaultTheme="light"
               attribute="class"
               enableSystem={false}
             >


### PR DESCRIPTION
- Removed unused import of PaymentManagement from @prisma/client in add-management.ts
- Added a new section for order summary in order-details.tsx
- Updated the styling and layout of the order details page
- Added a button to initiate return request in order-details.tsx
- Updated the data payload for return request in return-order-page.tsx
- Updated the default theme to "light" in layout.tsx